### PR TITLE
[Internal] Update remaining Develocity URLs to point to Commonhaus instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ so you can use that and don't need to care about the required version of Maven
 ### <a id="setup-develocity"></a> Develocity build cache and build scans
 
 Hibernate Validator relies on a [Develocity](https://gradle.com/develocity/) instance
-at [https://ge.hibernate.org](https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Validator)
+at [https://develocity.commonhaus.dev](https://develocity.commonhaus.dev/scans?search.rootProjectNames=Hibernate%20Validator)
 to speed up its build through a build cache and provide better reports.
 
 By default, only [continuous integration](#ci) builds will write to the remote build cache or publish build scans.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -572,7 +572,7 @@ void withMavenWorkspace(Map args, Closure body) {
 			artifactsPublisher(disabled: true),
 			// stdout/stderr for successful tests is not needed and takes up disk space
 			// we archive test results and stdout/stderr as part of the build scan anyway,
-			// see https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Validator
+			// see https://develocity.commonhaus.dev/scans?search.rootProjectNames=Hibernate%20Validator
 			junitPublisher(disabled: true)
 	])
 	helper.withMavenWorkspace(args, body)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://img.shields.io/jenkins/build?jobUrl=https://ci.hibernate.org/view/Validator/job/hibernate-validator/job/main/&style=for-the-badge)](https://ci.hibernate.org/view/Validator/job/hibernate-validator/job/main/)
 [![Sonar Coverage](https://img.shields.io/sonar/coverage/hibernate_hibernate-validator?server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge)](https://sonarcloud.io/project/activity?id=hibernate_hibernate-validator&graph=coverage)
 [![Quality gate](https://img.shields.io/sonar/alert_status/hibernate_hibernate-validator?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io&style=for-the-badge)](https://sonarcloud.io/dashboard?id=hibernate_hibernate-validator)
-[![Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?style=for-the-badge&logo=gradle)](https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Validator)
+[![Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?style=for-the-badge&logo=gradle)](https://develocity.commonhaus.dev/scans?search.rootProjectNames=Hibernate%20Validator)
 [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/hibernate/validator/hibernate-validator/badge.json&style=for-the-badge)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/hibernate/validator/hibernate-validator/README.md)
 
 ## What is it?

--- a/jenkins/nightly/Jenkinsfile
+++ b/jenkins/nightly/Jenkinsfile
@@ -17,7 +17,7 @@ def withMavenWorkspace(jdk, Closure body) {
 					artifactsPublisher(disabled: true),
 					// stdout/stderr for successful tests is not needed and takes up disk space
 					// we archive test results and stdout/stderr as part of the build scan anyway,
-					// see https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Search
+					// see https://develocity.commonhaus.dev/scans?search.rootProjectNames=Hibernate%20Search
 					junitPublisher(disabled: true)
 			]) {
 		body()


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

- Updated the Develocity Maven Extension's `server` to point to `https://develocity.commonhaus.dev`
- Changed other references from `ge.hibernate.org` to `develocity.commonhaus.dev`, most notably:
  - Develocity URL in Jenkinsfiles
  - `Revved up by Develocity` badge URL in README
  - Develocity URL in "Develocity build cache and build scans" section in CONTRIBUTING

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
